### PR TITLE
fixed instructions to source file rather than add to path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,20 @@ painless. The following steps (or variations on them) should get the job done
 its contents instead of copying to make updates easier):
 
 1.  Clone this repository.
-2.  Create the directory `$XDG_CONFIG_HOME/wenv` (or `$HOME/.config/wenv`) and
+2.  Put the `wenv` and `completion.bash` files wherever you like, and add the
+    following lines to source them in your Zsh profile (or another Zsh startup
+    file):
+
+    .. code-block:: bash
+
+        # source wenv file
+        source <path-to-wenv-file> 
+        # enable bash completion functions 
+        autoload bashcompinit
+        bashcompinit 
+        # source wenv completion file 
+        source <path-to-completion.bash>
+3.  Create the directory `$XDG_CONFIG_HOME/wenv` (or `$HOME/.config/wenv`) and
     put the `template` file there and `extensions` directory there. Also, create
     a directory inside of that `wenv` directory called `wenvs`, which will store
     the wenv files for all of your projects. If you're in this repository, you
@@ -125,7 +138,7 @@ its contents instead of copying to make updates easier):
         mkdir -p "$wenv_cfg/wenvs"
         ln -s <path-to-this-repo>/{template,extensions} "$wenv_cfg"
 
-3.  In order for wenvs to work with `tmux`, the following line should be added
+4.  In order for wenvs to work with `tmux`, the following line should be added
     to your `zshrc`:
 
     .. code-block:: bash
@@ -134,19 +147,6 @@ its contents instead of copying to make updates easier):
 
     This makes it so that the wenv associated with a given tmux session can be
     loaded whenever a new pane or window is opened within that session.
-4.  Put the `wenv` and `completion.bash` files wherever you like, and add the
-    following lines to source it in your Zsh profile (or another Zsh startup
-    file):
-
-    .. code-block:: bash
-
-        # source wenv file
-        source <path-to-wenv-file> 
-        # enable bash completion functions 
-        autoload
-        bashcompinit bashcompinit 
-        # source wenv completion file 
-        source <path-to-completion.bash>
 
 Dependencies
 ~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -113,10 +113,7 @@ painless. The following steps (or variations on them) should get the job done
 its contents instead of copying to make updates easier):
 
 1.  Clone this repository.
-2.  Put the `wenv` file in a directory that's in your `PATH` (e.g.
-    `$HOME/.local/bin`). `wenv` is a Zsh script that defines all of the
-    relevant functionality.
-3.  Create the directory `$XDG_CONFIG_HOME/wenv` (or `$HOME/.config/wenv`) and
+2.  Create the directory `$XDG_CONFIG_HOME/wenv` (or `$HOME/.config/wenv`) and
     put the `template` file there and `extensions` directory there. Also, create
     a directory inside of that `wenv` directory called `wenvs`, which will store
     the wenv files for all of your projects. If you're in this repository, you
@@ -128,7 +125,7 @@ its contents instead of copying to make updates easier):
         mkdir -p "$wenv_cfg/wenvs"
         ln -s <path-to-this-repo>/{template,extensions} "$wenv_cfg"
 
-4.  In order for wenvs to work with `tmux`, the following line should be added
+3.  In order for wenvs to work with `tmux`, the following line should be added
     to your `zshrc`:
 
     .. code-block:: bash
@@ -137,15 +134,18 @@ its contents instead of copying to make updates easier):
 
     This makes it so that the wenv associated with a given tmux session can be
     loaded whenever a new pane or window is opened within that session.
-5.  Put the `completion.bash` file wherever you like, and add the following
-    lines to source it in your Zsh profile (or another Zsh startup file):
+4.  Put the `wenv` and `completion.bash` files wherever you like, and add the
+    following lines to source it in your Zsh profile (or another Zsh startup
+    file):
 
     .. code-block:: bash
 
-        # enable bash completion functions
-        autoload bashcompinit
-        bashcompinit
-        # source wenv completion file
+        # source wenv file
+        source <path-to-wenv-file> 
+        # enable bash completion functions 
+        autoload
+        bashcompinit bashcompinit 
+        # source wenv completion file 
         source <path-to-completion.bash>
 
 Dependencies

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,19 @@ painless. The following steps (or variations on them) should get the job done
 its contents instead of copying to make updates easier):
 
 1.  Clone this repository.
-2.  Put the `wenv` and `completion.bash` files wherever you like, and add the
+2.  Create the directory `$XDG_CONFIG_HOME/wenv` (or `$HOME/.config/wenv`) and
+    put the `template` file there and `extensions` directory there. Also, create
+    a directory inside of that `wenv` directory called `wenvs`, which will store
+    the wenv files for all of your projects. If you're in this repository, you
+    can run the following lines to complete this step:
+
+    .. code-block:: bash
+
+        export wenv_cfg="${XDG_CONFIG_HOME:-$HOME/.config}/wenv"
+        mkdir -p "$wenv_cfg/wenvs"
+        ln -s <path-to-this-repo>/{template,extensions} "$wenv_cfg"
+
+3.  Put the `wenv` and `completion.bash` files wherever you like, and add the
     following lines to source them in your Zsh profile (or another Zsh startup
     file):
 
@@ -126,17 +138,6 @@ its contents instead of copying to make updates easier):
         bashcompinit 
         # source wenv completion file 
         source <path-to-completion.bash>
-3.  Create the directory `$XDG_CONFIG_HOME/wenv` (or `$HOME/.config/wenv`) and
-    put the `template` file there and `extensions` directory there. Also, create
-    a directory inside of that `wenv` directory called `wenvs`, which will store
-    the wenv files for all of your projects. If you're in this repository, you
-    can run the following lines to complete this step:
-
-    .. code-block:: bash
-
-        export wenv_cfg="${XDG_CONFIG_HOME:-$HOME/.config}/wenv"
-        mkdir -p "$wenv_cfg/wenvs"
-        ln -s <path-to-this-repo>/{template,extensions} "$wenv_cfg"
 
 4.  In order for wenvs to work with `tmux`, the following line should be added
     to your `zshrc`:


### PR DESCRIPTION
I combined step two with step five because they both source files (the wenv file and the bash completion). Let me know if you want it more split up than that.

Also, I imagine you are formatting the `README.rst` with pandoc, but when I ran it with defaults it changed a bunch. Feel free to shoot me the exact command you are using and I can run it before merging.