### PR TITLE
Pass path of wenv directory to wenv new command

### DIFF
--- a/wenv
+++ b/wenv
@@ -297,21 +297,21 @@ OPTIONS
     while getopts ":d:i:h" opt; do
         case $opt in
             d)
-                [[ ! -z "$OPTARG" ]] && local wenv_dir="$OPTARG"
+                local wenv_dir="$OPTARG"
                 ;;
             i)
-                [[ ! -z "$OPTARG" ]] && template="$WENV_CFG/wenvs/${OPTARG}"
+                template="$WENV_CFG/wenvs/${OPTARG}"
                 ;;
             h)
                 echo "$usage"
                 return 0
                 ;;
             :)
-                echo "unknown option: $OPTARG requires and argument" >&2
+                echo "unknown option: $OPTARG requires an argument" >&2
                 return 1
                 ;;
             \?)
-                echo "unknown option: -$OPTARG start" >&2
+                echo "unknown option: -$OPTARG" >&2
                 return 1
                 ;;
         esac
@@ -321,7 +321,7 @@ OPTIONS
     [[ -z "$1" ]] && return 1
     local wenv="$1"
 
-    cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=$wenv_dir|$template") > "$WENV_CFG/wenvs/$wenv"
+    cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=$wenv_dir| $template") > "$WENV_CFG/wenvs/$wenv"
 
     wenv_edit "$wenv"
 }

--- a/wenv
+++ b/wenv
@@ -283,10 +283,10 @@ run_wenv_def() {
 wenv_new() {
     local usage="\
 USAGE
-  wenv new [-d] [-i <wenv>] [-h] <name> - Create a new wenv called <name>.
+  wenv new [-d <base_dir>] [-i <wenv>] [-h] <name> - Create a new wenv called <name>.
 
 OPTIONS
-  -d        Set the cwd as the new wenv's base directory (i.e. WENV_DIR).
+  -d        Initialize wenv with <base_dir> as the new wenv's base directory rather than the cwd (i.e. WENV_DIR).
   -i <wenv> Use <wenv>'s wenv file as the initial definition for the new wenv.
   -h        Display this help message.
 "
@@ -314,14 +314,17 @@ OPTIONS
     shift $((OPTIND-1))
 
     [[ -z "$1" ]] && return 1
-    local wenv="$1"
 
     # TODO: generalize/clean this up
     if [[ $flag_d -eq 1 ]]; then
-        cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=\"`pwd`\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
+        [[ -z "$2" ]] && echo "directory path and wenv name arguments are required with the -d flag" && return 1
+        local wenv_dir="$1"
+        local wenv="$2"
+        cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=\"`echo $wenv_dir`\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
     else
         # this case shouldn't be exclusive from previous
-        cp "$template" "$WENV_CFG/wenvs/$wenv"
+        local wenv="$1"
+        cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=\"`pwd`\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
     fi
     wenv_edit "$wenv"
 }

--- a/wenv
+++ b/wenv
@@ -283,20 +283,21 @@ run_wenv_def() {
 wenv_new() {
     local usage="\
 USAGE
-  wenv new [-d <base_dir>] [-i <wenv>] [-h] <name> - Create a new wenv called <name>.
+  wenv new [-d <dir>] [-i <wenv>] [-h] <name> - Create a new wenv called <name>.
 
 OPTIONS
-  -d        Initialize wenv with <base_dir> as the new wenv's base directory rather than the cwd (i.e. WENV_DIR).
+  -d        Initialize wenv with <dir> as the new wenv's base directory rather than the current working directory.
   -i <wenv> Use <wenv>'s wenv file as the initial definition for the new wenv.
   -h        Display this help message.
 "
 
     local template="$WENV_CFG/template"
     local flag_d=0
-    while getopts ":di:h" opt; do
+    local wenv_dir=$(pwd)
+    while getopts ":d:i:h" opt; do
         case $opt in
             d)
-                flag_d=1
+                [[ ! -z "$OPTARG" ]] && local wenv_dir="$OPTARG"
                 ;;
             i)
                 [[ ! -z "$OPTARG" ]] && template="$WENV_CFG/wenvs/${OPTARG}"
@@ -305,8 +306,12 @@ OPTIONS
                 echo "$usage"
                 return 0
                 ;;
+            :)
+                echo "unknown option: $OPTARG requires and argument" >&2
+                return 1
+                ;;
             \?)
-                echo "unknown option: -$OPTARG" >&2
+                echo "unknown option: -$OPTARG start" >&2
                 return 1
                 ;;
         esac
@@ -314,18 +319,10 @@ OPTIONS
     shift $((OPTIND-1))
 
     [[ -z "$1" ]] && return 1
+    local wenv="$1"
 
-    # TODO: generalize/clean this up
-    if [[ $flag_d -eq 1 ]]; then
-        [[ -z "$2" ]] && echo "directory path and wenv name arguments are required with the -d flag" && return 1
-        local wenv_dir="$1"
-        local wenv="$2"
-        cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=\"`echo $wenv_dir`\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
-    else
-        # this case shouldn't be exclusive from previous
-        local wenv="$1"
-        cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=\"`pwd`\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
-    fi
+    cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=$wenv_dir|$template") > "$WENV_CFG/wenvs/$wenv"
+
     wenv_edit "$wenv"
 }
 


### PR DESCRIPTION
Per our conversation, we will switch the current `-d` behavior to be the default behavior (use the pwd) and use the `-d` flag for passing a directory that isn't the pwd. 