### PR TITLE
Perl command failing on arch box

### DIFF
--- a/wenv
+++ b/wenv
@@ -321,7 +321,7 @@ OPTIONS
     [[ -z "$1" ]] && return 1
     local wenv="$1"
 
-    cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=$wenv_dir| $template") > "$WENV_CFG/wenvs/$wenv"
+    cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=\"$wenv_dir\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
 
     wenv_edit "$wenv"
 }


### PR DESCRIPTION
https://github.com/dgrisham/wenv/blob/09c6caefcf2834ee8b0f98fd45319d3ba8069ba6/wenv#L324
is failing for me on my arch machine with the error:

```
syntax error at -e line 1, near "/."
Execution of -e aborted due to compilation errors.
```