### PR TITLE
support user-defined function for updating prompt with wenv, use sensible default otherwise

### DIFF
--- a/wenv
+++ b/wenv
@@ -191,7 +191,11 @@ wenv_exec() {
     wenv_source "$WENV" || { echo "failed to source wenv '$WENV'" >&2 ; return 1 }
 
     export ORIGINAL_PS1="$PS1"
-    export PS1="($WENV) $ORIGINAL_PS1"
+    if function_exists add_wenv_to_prompt; then
+        export PS1=$(add_wenv_to_prompt "$ORIGINAL_PS1")
+    else
+        export PS1="($WENV) $ORIGINAL_PS1"
+    fi
 
     ((flag_c == 1)) && cd "$WENV_DIR" &> /dev/null
 


### PR DESCRIPTION
If user defines the function `add_wenv_to_prompt`, then use that to update the prompt with the wenv info. Otherwise just prepend `($WENV) ` to the prompt like we used to do.