### PR TITLE
heavy clean up on how wenv source works + defining wenv vars

### DIFF
--- a/template
+++ b/template
@@ -1,14 +1,14 @@
 #!/usr/bin/env zsh
 
-wenv_def() {
-    WENV_DIR=""
-    WENV_DEPS=()
-    WENV_EXTENSIONS=('c')
+wenv_dir=""
+wenv_deps=()
+wenv_extensions=('c')
 
-    startup_wenv() {}
-    shutdown_wenv() {}
-    bootstrap_wenv() {}
-}
+startup_wenv() {}
+shutdown_wenv() {}
+bootstrap_wenv() {}
+
+((only_load_wenv_vars == 1)) && return 0
 
 # for c extension
 # declare -Ag wenv_dirs=()

--- a/wenv
+++ b/wenv
@@ -490,7 +490,12 @@ DESCRIPTION
     fi
     local wenv="$1"
 
+    unset wenv_dir
     only_load_wenv_vars=1 source $WENV_CFG/wenvs/$wenv
+
+    [[ -z "$wenv_dir" ]] && { echo "wenv_dir not defined for wenv '$wenv'" >&2 ; return 1 }
+
+    cd $wenv_dir
 
     return 0
 }

--- a/wenv
+++ b/wenv
@@ -1,14 +1,12 @@
 #!/usr/bin/env zsh
 
-wenv_def() {
-    WENV_DIR="$SRC/wenv"
-    WENV_DEPS=()
-    WENV_EXTENSIONS=('c')
+wenv_dir="$SRC/wenv"
+wenv_deps=()
+wenv_extensions=('c')
 
-    bootstrap_wenv() {}
-    startup_wenv() {}
-    shutdown_wenv() {}
-}
+bootstrap_wenv() {}
+startup_wenv() {}
+shutdown_wenv() {}
 
 export WENV_CFG="${XDG_CONFIG_HOME:-$HOME/.config}/wenv"
 
@@ -28,7 +26,7 @@ SUBCOMMANDS
   edit <wenv>           Edit the wenv file for <wenv>.
   rename <old> <new>    Rename wenv <old> to <new>.
   remove <wenv>         Delete the wenv file for <wenv>.
-  source <wenv>         Source <wenv>'s environment (excluding its wenv_def).
+  source <wenv>         Source the wenv file for <wenv>.
   cd <wenv>             Change to <wenv>'s base directory.
   extension <cmd>       Interact with wenv extensions.
   bootstrap <wenv>      Run <wenv>'s bootstrap function.
@@ -181,24 +179,69 @@ OPTIONS
 }
 
 wenv_exec() {
-    local flag_c=1
-
-    local opt OPTIND
-    while getopts ":c" opt; do
-        case $opt in
-            c) flag_c=0 ;;
-        esac
-    done
-    shift $((OPTIND-1))
-
     [[ -z "$1" ]] && return 1
     export WENV="$1"
 
     wenv_source || { echo "failed to source wenv '$WENV'" >&2 ; return 1 }
 
-    ((flag_c == 1)) && cd "$WENV_DIR" &> /dev/null
+    cd "$wenv_dir" &> /dev/null
 
     return 0
+}
+
+wenv_source() {
+    local usage="\
+USAGE
+  wenv source [-h] [<wenv>, ...] - Source active wenv + its dependencies.
+
+OPTIONS
+  -h    Display this help message.
+
+DESCRIPTION
+  \`wenv source\` sources the active wenv's aliases and its dependencies.
+"
+
+    [[ -z "$WENV" ]] && { echo "error sourcing active wenv: \$WENV is empty" >&2 ; return 1 }
+
+    local opt OPTIND
+    while getopts ":h" opt; do
+        case "$opt" in
+            h)
+                echo "$usage"
+                return 0
+                ;;
+            \?)
+                echo "unknown option: -$OPTARG" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    only_load_wenv_vars=1 source $WENV_CFG/wenvs/$WENV
+
+    export WENV_DIR=$wenv_dir
+    export WENV_DEPS=$wenv_deps
+    export WENV_EXTENSIONS=$wenv_extensions
+
+    ((${#WENV_EXTENSIONS[@]} != 0)) && wenv_extension_load "${WENV_EXTENSIONS[@]}"
+    ((${#WENV_DEPS[@]} != 0)) && source_wenv_dependencies_recursively "${WENV_DEPS[@]}"
+
+    source $WENV_CFG/wenvs/$WENV
+
+    return 0
+}
+
+source_wenv_dependencies_recursively() {
+    local wenv
+    for wenv in $@; do
+        unset_quiet wenv_deps
+
+        only_load_wenv_vars=1 source "$WENV_CFG/wenvs/$wenv"
+        eval source_wenv_dependencies_recursively $wenv_deps
+
+        # source this wenv now that its dependencies are loaded
+        source $WENV_CFG/wenvs/$wenv
+    done
 }
 
 wenv_stop() {
@@ -249,29 +292,13 @@ wenv_clean_up() {
     [[ -z "$WENV" ]] && return 1
 
     unset_quiet WENV
-    unset_wenv_vars
+    unset_quiet WENV_{DIR,DEPS,EXTENSIONS}
     unset_quiet -f {bootstrap,startup,shutdown}_wenv
 
     if [[ -n "$TMUX" ]]; then
         tmux set-environment WENV ''
         tmux rename-session $(tmux display-message -p '#{session_id}' | tr -d '$')
     fi
-}
-
-unset_wenv_vars() {
-    unset_quiet WENV_{DIR,DEPS}
-}
-
-source_wenv_and_run_wenv_def() {
-    [[ -z "$1" ]] && return 1
-    local wenv="$1"
-    unset_quiet -f wenv_def
-    source $WENV_CFG/wenvs/$wenv
-    if ! function_exists wenv_def; then
-        echo "wenv_def not defined for wenv '$1'" >&2
-        return 1
-    fi
-    wenv_def
 }
 
 wenv_new() {
@@ -324,7 +351,7 @@ OPTIONS
     fi
 
     mkdir -p $WENV_CFG/wenvs/$(dirname $wenv)
-    cat =(perl -pe "s|WENV_DIR=.*?$|WENV_DIR=\"$wenv_dir\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
+    cat =(perl -pe "s|wenv_dir=.*?$|wenv_dir=\"$wenv_dir\"|" "$template") > "$WENV_CFG/wenvs/$wenv"
 
     wenv_edit "$wenv"
 }
@@ -420,54 +447,6 @@ OPTIONS
     eval "rm $rm_args $wenv_file"
 }
 
-wenv_source() {
-    local usage="\
-USAGE
-  wenv source [-h] [<wenv>, ...] - Source one or more wenvs + their dependencies.
-
-OPTIONS
-  -h    Display this help message.
-
-DESCRIPTION
-  \`wenv source\` sources the active wenv's aliases and its dependencies.
-"
-
-    [[ -z "$WENV" ]] && { echo "error sourcing active wenv: \$WENV is empty" >&2 ; return 1 }
-
-    local opt OPTIND
-    while getopts ":h" opt; do
-        case "$opt" in
-            h)
-                echo "$usage"
-                return 0
-                ;;
-            \?)
-                echo "unknown option: -$OPTARG" >&2
-                return 1
-                ;;
-        esac
-    done
-
-    eval "$(grep -Eho '^\s*WENV_(DIR|DEPS|EXTENSIONS)=(.*)' $WENV_CFG/wenvs/$WENV)"
-    ((${#WENV_EXTENSIONS[@]} != 0)) && wenv_extension_load "${WENV_EXTENSIONS[@]}"
-    ((${#WENV_DEPS[@]} != 0)) && source_wenv_dependencies_recursively "${WENV_DEPS[@]}"
-
-    source_wenv_and_run_wenv_def "$WENV"
-
-    return 0
-}
-
-source_wenv_dependencies_recursively() {
-    local wenv
-    for wenv in $@; do
-        # grep for the WENV_DEPS for this wenv and recursively source those
-        eval source_wenv_dependencies_recursively "$(grep -Pho '^\s*WENV_DEPS=\(\K.*(?=\))' $WENV_CFG/wenvs/$wenv)"
-        # source this wenv now that its dependencies are loaded
-        source $WENV_CFG/wenvs/$wenv
-        unset wenv_def
-    done
-}
-
 wenv_cd() {
     local usage="\
 USAGE
@@ -482,7 +461,7 @@ DESCRIPTION
 
   Calling as \`wenv cd <wenv>\` will \`cd\` into <wenv>'s base directory.
 
-  The base directory of a wenv is defined by its WENV_DIR value.
+  The base directory of a wenv is defined by its \`wenv_dir\` value.
 "
 
     local opt OPTIND
@@ -501,7 +480,7 @@ DESCRIPTION
     shift $((OPTIND-1))
 
     if [[ -z "$1" ]]; then
-        [[ ! -z "$WENV_DIR" ]] && cd "$WENV_DIR" &> /dev/null
+        [[ -n "$WENV_DIR" ]] && cd "$WENV_DIR" &> /dev/null
         return 0
     fi
 
@@ -511,7 +490,7 @@ DESCRIPTION
     fi
     local wenv="$1"
 
-    eval cd $(grep -Pho '^\s*WENV_DIR=\K.*' $WENV_CFG/wenvs/$wenv)
+    only_load_wenv_vars=1 source $WENV_CFG/wenvs/$wenv
 
     return 0
 }
@@ -590,7 +569,7 @@ DESCRIPTION
     # clear out bootstrap_wenv if we're in an active wenv
     [[ -n "$WENV" ]] && unset_quiet -f bootstrap_wenv
 
-    source_wenv_and_run_wenv_def "$wenv"
+    only_load_wenv_vars=1 source $WENV_CFG/wenvs/$wenv
     if ! function_exists bootstrap_wenv; then
         echo "bootstrap_wenv not defined for wenv '$1'" >&2
         return 1
@@ -665,7 +644,7 @@ ARGUMENTS
 DESCRIPTION
   This function sources the corresponding extension file at \$WENV_CFG/<extension>.
   This will only source the extension file in the current shell. See the
-  documentation on the WENV_EXTENSIONS environment variable for loading an
+  documentation on the \`wenv_extensions\` configuration variable for loading an
   extension in every shell of a wenv.
 "
 

--- a/wenv
+++ b/wenv
@@ -194,8 +194,7 @@ wenv_exec() {
     [[ -z "$1" ]] && return 1
     export WENV="$1"
 
-    run_wenv_def "$WENV" || { echo "wenv_def() not defined for wenv '$WENV'" >&2 ; return 1 }
-    wenv_source "$WENV" || { echo "failed to source wenv '$WENV'" >&2 ; return 1 }
+    wenv_source || { echo "failed to source wenv '$WENV'" >&2 ; return 1 }
 
     ((flag_c == 1)) && cd "$WENV_DIR" &> /dev/null
 
@@ -259,27 +258,20 @@ wenv_clean_up() {
     fi
 }
 
-load_wenv_vars() {
-    unset_wenv_vars
-    run_wenv_def "$@"
-    unset_quiet -f bootstrap_wenv,startup_wenv,shutdown_wenv
-}
-
 unset_wenv_vars() {
     unset_quiet WENV_{DIR,DEPS}
 }
 
-run_wenv_def() {
+source_wenv_and_run_wenv_def() {
     [[ -z "$1" ]] && return 1
     local wenv="$1"
     unset_quiet -f wenv_def
-    source $WENV_CFG/wenvs/$wenv >/dev/null 2>&1
+    source $WENV_CFG/wenvs/$wenv
     if ! function_exists wenv_def; then
         echo "wenv_def not defined for wenv '$1'" >&2
         return 1
     fi
     wenv_def
-    unset_quiet -f wenv_def
 }
 
 wenv_new() {
@@ -437,12 +429,10 @@ OPTIONS
   -h    Display this help message.
 
 DESCRIPTION
-  Calling \`wenv source\` with no arguments will source the active wenv's
-  aliases and its dependencies.
-
-  Calling as \`wenv source [<wenv>, ...]\` will source the aliases of every
-  wenv in the argument list, as well as each wenv's dependencies.
+  \`wenv source\` sources the active wenv's aliases and its dependencies.
 "
+
+    [[ -z "$WENV" ]] && { echo "error sourcing active wenv: \$WENV is empty" >&2 ; return 1 }
 
     local opt OPTIND
     while getopts ":h" opt; do
@@ -458,40 +448,32 @@ DESCRIPTION
         esac
     done
 
-    if (($# == 0)); then
-        source_wenvs_recursively "$WENV"
-        run_wenv_def "$WENV"
-    else
-        source_wenvs_recursively $@
-        [[ -n "$WENV" ]] && run_wenv_def "$WENV"
-    fi
+    eval "$(grep -Eho '^\s*WENV_(DIR|DEPS|EXTENSIONS)=(.*)' $WENV_CFG/wenvs/$WENV)"
+    ((${#WENV_EXTENSIONS[@]} != 0)) && wenv_extension_load "${WENV_EXTENSIONS[@]}"
+    ((${#WENV_DEPS[@]} != 0)) && source_wenv_dependencies_recursively "${WENV_DEPS[@]}"
+
+    source_wenv_and_run_wenv_def "$WENV"
 
     return 0
 }
 
-source_wenvs_recursively() {
+source_wenv_dependencies_recursively() {
     local wenv
     for wenv in $@; do
-        if ! is_wenv "$1"; then
-            echo "wenv '$1' doesn't exist" >&2
-            return 1
-        fi
-
-        load_wenv_vars "$wenv"
-        ((${#WENV_EXTENSIONS[@]} != 0)) && wenv_extension_load "${WENV_EXTENSIONS[@]}"
-        ((${#WENV_DEPS[@]} != 0)) && source_wenvs_recursively "${WENV_DEPS[@]}" && load_wenv_vars "$wenv"
-        source "$WENV_CFG/wenvs/$wenv" >/dev/null
+        # grep for the WENV_DEPS for this wenv and recursively source those
+        eval source_wenv_dependencies_recursively "$(grep -Pho '^\s*WENV_DEPS=\(\K.*(?=\))' $WENV_CFG/wenvs/$wenv)"
+        # source this wenv now that its dependencies are loaded
+        source $WENV_CFG/wenvs/$wenv
+        unset wenv_def
     done
-    unset_wenv_vars
 }
 
 wenv_cd() {
     local usage="\
 USAGE
-  wenv cd [-r] [-h] <wenv> - cd into <wenv>'s base directory.
+  wenv cd [-h] <wenv> - cd into <wenv>'s base directory.
 
 OPTIONS
-  -r    Rename the current tmux window to the designated wenv's name (<wenv>).
   -h    Display this help message.
 
 DESCRIPTION
@@ -503,14 +485,9 @@ DESCRIPTION
   The base directory of a wenv is defined by its WENV_DIR value.
 "
 
-    local flag_r=0
-
     local opt OPTIND
-    while getopts ":rh" opt; do
+    while getopts ":h" opt; do
         case $opt in
-            r)
-               flag_r=1
-               ;;
             h)
                 echo "$usage"
                 return 0
@@ -525,7 +502,6 @@ DESCRIPTION
 
     if [[ -z "$1" ]]; then
         [[ ! -z "$WENV_DIR" ]] && cd "$WENV_DIR" &> /dev/null
-        ((flag_r == 1)) && tmux rename-window "$WENV"
         return 0
     fi
 
@@ -535,16 +511,7 @@ DESCRIPTION
     fi
     local wenv="$1"
 
-    # TODO: need a better way to do this
-    # load and cd to input wenv
-    load_wenv_vars "$wenv"
-    cd "$WENV_DIR"
-    unset_wenv_vars
-
-    # reload the wenv that was previously running
-    run_wenv_def "$WENV"
-
-    ((flag_r == 1)) && tmux rename-window "$wenv"
+    eval cd $(grep -Pho '^\s*WENV_DIR=\K.*' $WENV_CFG/wenvs/$wenv)
 
     return 0
 }
@@ -620,11 +587,15 @@ DESCRIPTION
     fi
     local wenv="$1"
 
-    run_wenv_def "$wenv"
+    # clear out bootstrap_wenv if we're in an active wenv
+    [[ -n "$WENV" ]] && unset_quiet -f bootstrap_wenv
+
+    source_wenv_and_run_wenv_def "$wenv"
     if ! function_exists bootstrap_wenv; then
         echo "bootstrap_wenv not defined for wenv '$1'" >&2
         return 1
     fi
+
     bootstrap_wenv
     unset_quiet -f bootstrap_wenv
 }


### PR DESCRIPTION
Trading one evil for another. Right now we have a the mess of sourcing wenvs/running `wenv_def`/unsetting vars/etc., which shows up particularly messy in `wenv_source` and `source_wenvs_recursively`. With this PR, every time we need to load a wenv var and we don't want to run `wenv_def`, we instead grep for the line that defines that(those) var(s) and `eval` the line(s).

This primarily affects:
- `wenv_source`: This would unnecessarily reload the wenv multiple times. Now it loads everything it needs exactly once (including the calls to `source_wenv_dependencies_recursively`, which replaced `source_wenvs_recursively`).
- `wenv_cd`: This finally doesn't have to load an entire wenv + call its `wenv_def`, cd to the `WENV_DIR`, then reload the existing wenv -- instead we just grep for the `WENV_DIR` from the desired destination and cd to it.
- `load_wenv_vars`: This function has been removed. It sourced the wenv, ran the `wenv_def`, and unloaded the functions so that just the wenv vars would be defined. Now we don't need this.

The implications of this are that we expect exactly one line in the file for each of the wenv vars, in the following form (all on a single line):
- `WENV_DIR=<directory>`
- `WENV_DEPS=(<dep1> <dep2> ...)`
- `WENV_EXTENSIONS=(<extension1> <extension2> ...)`

Whitespace is allowed before the variable name (but nothing else is, including `export`, which isn't in the template anyway). This is why everything was the way it was, because it seemed cleaner to let the shell evaluate all of the lines so we wouldn't have to clumsily grep for variable definitions with a restricted format. However, this doesn't seem like a big deal, as these variables are relatively simple (though the strictness of the format should be documented if we go this route). There may also be other ways to solve these problems, but that'd likely involve deeper tooling/a refactor that we can do later. Note that there *can* be a comment after the definition (e.g. `WENV_DIR=$HOME/blah # hello friend`) because `eval` will just ignore it. This seems worth the simplified state management + only loading a wenv once and running the `wenv_def` + loading the exact vars we care about.

Minor additional change:
- `wenv_cd`'s `-r` flag has been removed (this was the flag that'd rename the tmux window to the arg wenv; no one uses this)